### PR TITLE
fix(artifacts): Raise CodeNotFound on empty array from GCS list operation

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -87,6 +87,10 @@ func downloadObjects(client *storage.Client, bucket, key, path string) error {
 	if err != nil {
 		return err
 	}
+	if len(objNames) < 1 {
+		msg := fmt.Sprintf("no results for key: %s", key)
+		return errors.New(errors.CodeNotFound, msg)
+	}
 	for _, objName := range objNames {
 		err = downloadObject(client, bucket, key, objName, path)
 		if err != nil {


### PR DESCRIPTION
I believe this resolves https://github.com/pollination/queenbee-argo/issues/127

I forked from the tag that we are using on the cluster right now (v3.1.0-rc14).

We may want to push master to be at that tag before merging this though.